### PR TITLE
feat(cli): add --start, --all-day, --timezone options to task create/update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "dida365-ai-tools",
-  "version": "2.0.0",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dida365-ai-tools",
-      "version": "2.0.0",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
         "commander": "^12.1.0",
-        "dotenv": "^16.4.0",
         "zod": "^3.23.0"
       },
       "bin": {
@@ -301,18 +300,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/skills/dida365-cli/SKILL.md
+++ b/skills/dida365-cli/SKILL.md
@@ -60,13 +60,13 @@ dida365 task delete <taskId> <projectId>
 参数说明：
 - `-p, --project <projectId>` — 项目 ID（必填）
 - `-t, --title <title>` — 任务标题（update 时可选）
-- `-c, --content <content>` — 任务内容
+- `-c, --content <content>` — 任务内容（富文本/笔记）
+- `--desc <description>` — 任务描述（纯文本，显示在列表/日历视图）
 - `-s, --start <date>` — 开始日期（ISO 8601）
 - `-d, --due <date>` — 截止日期（ISO 8601）
 - `--all-day` / `--no-all-day` — 全天任务标记
 - `--timezone <tz>` — 时区（如 `Asia/Shanghai`）
 - `--priority <n>` — 优先级：0=无, 1=低, 3=中, 5=高
-- `-j, --json` — JSON 格式输出
 - `-j, --json` — JSON 格式输出
 
 ## 4. 已完成任务查询

--- a/skills/dida365-cli/SKILL.md
+++ b/skills/dida365-cli/SKILL.md
@@ -39,6 +39,7 @@ dida365 project show <projectId> --json
 # 创建任务
 dida365 task create <title> -p <projectId>
 dida365 task create <title> -p <projectId> -c <content> --priority <0|1|3|5> -d <dueDate>
+dida365 task create <title> -p <projectId> -s <startDate> -d <dueDate> --all-day --timezone "Asia/Shanghai"
 
 # 查看任务
 dida365 task show <taskId>
@@ -47,20 +48,25 @@ dida365 task show <taskId> --json
 # 更新任务
 dida365 task update <taskId> -p <projectId> -t <newTitle>
 dida365 task update <taskId> -p <projectId> -c <content> --priority <0|1|3|5> -d <dueDate>
+dida365 task update <taskId> -p <projectId> -s <startDate> -d <dueDate> --all-day
 
-# 完成任务
-dida365 task complete <projectId> <taskId>
+# 完成任务（注意：参数顺序是 taskId 在前）
+dida365 task complete <taskId> <projectId>
 
 # 删除任务（危险操作，删除前需确认）
-dida365 task delete <projectId> <taskId>
+dida365 task delete <taskId> <projectId>
 ```
 
 参数说明：
 - `-p, --project <projectId>` — 项目 ID（必填）
 - `-t, --title <title>` — 任务标题（update 时可选）
 - `-c, --content <content>` — 任务内容
+- `-s, --start <date>` — 开始日期（ISO 8601）
 - `-d, --due <date>` — 截止日期（ISO 8601）
+- `--all-day` / `--no-all-day` — 全天任务标记
+- `--timezone <tz>` — 时区（如 `Asia/Shanghai`）
 - `--priority <n>` — 优先级：0=无, 1=低, 3=中, 5=高
+- `-j, --json` — JSON 格式输出
 - `-j, --json` — JSON 格式输出
 
 ## 4. 已完成任务查询

--- a/src/cli/commands/task.cmd.ts
+++ b/src/cli/commands/task.cmd.ts
@@ -13,7 +13,8 @@ export function taskCommands(program: Command) {
     .command("create <title>")
     .description("Create a new task")
     .requiredOption("-p, --project <projectId>", "Project ID")
-    .option("-c, --content <content>", "Task content/description")
+    .option("-c, --content <content>", "Task content/notes")
+    .option("--desc <description>", "Task description (plain text, shown in list views)")
     .option("-s, --start <date>", "Start date (ISO 8601 format)")
     .option("-d, --due <date>", "Due date (ISO 8601 format)")
     .option("--all-day", "Mark as all-day task")
@@ -33,6 +34,10 @@ export function taskCommands(program: Command) {
 
         if (options.content) {
           taskData.content = options.content;
+        }
+
+        if (options.desc) {
+          taskData.desc = options.desc;
         }
 
         if (options.start) {
@@ -104,7 +109,8 @@ export function taskCommands(program: Command) {
     .description("Update an existing task")
     .requiredOption("-p, --project <projectId>", "Project ID")
     .option("-t, --title <title>", "New title")
-    .option("-c, --content <content>", "New content/description")
+    .option("-c, --content <content>", "New content/notes")
+    .option("--desc <description>", "New description (plain text)")
     .option("-s, --start <date>", "New start date (ISO 8601 format)")
     .option("-d, --due <date>", "New due date (ISO 8601 format)")
     .option("--all-day", "Mark as all-day task")
@@ -124,6 +130,7 @@ export function taskCommands(program: Command) {
 
         if (options.title) updates.title = options.title;
         if (options.content) updates.content = options.content;
+        if (options.desc) updates.desc = options.desc;
         if (options.start) updates.startDate = options.start;
         if (options.due) updates.dueDate = options.due;
         if (options.allDay === true) updates.isAllDay = true;

--- a/src/cli/commands/task.cmd.ts
+++ b/src/cli/commands/task.cmd.ts
@@ -14,7 +14,10 @@ export function taskCommands(program: Command) {
     .description("Create a new task")
     .requiredOption("-p, --project <projectId>", "Project ID")
     .option("-c, --content <content>", "Task content/description")
+    .option("-s, --start <date>", "Start date (ISO 8601 format)")
     .option("-d, --due <date>", "Due date (ISO 8601 format)")
+    .option("--all-day", "Mark as all-day task")
+    .option("--timezone <tz>", "Time zone (e.g. Asia/Shanghai)")
     .option(
       "--priority <priority>",
       "Priority (0=none, 1=low, 3=medium, 5=high)",
@@ -32,8 +35,20 @@ export function taskCommands(program: Command) {
           taskData.content = options.content;
         }
 
+        if (options.start) {
+          taskData.startDate = options.start;
+        }
+
         if (options.due) {
           taskData.dueDate = options.due;
+        }
+
+        if (options.allDay) {
+          taskData.isAllDay = true;
+        }
+
+        if (options.timezone) {
+          taskData.timeZone = options.timezone;
         }
 
         if (options.priority) {
@@ -90,7 +105,11 @@ export function taskCommands(program: Command) {
     .requiredOption("-p, --project <projectId>", "Project ID")
     .option("-t, --title <title>", "New title")
     .option("-c, --content <content>", "New content/description")
+    .option("-s, --start <date>", "New start date (ISO 8601 format)")
     .option("-d, --due <date>", "New due date (ISO 8601 format)")
+    .option("--all-day", "Mark as all-day task")
+    .option("--no-all-day", "Unmark all-day task")
+    .option("--timezone <tz>", "Time zone (e.g. Asia/Shanghai)")
     .option(
       "--priority <priority>",
       "Priority (0=none, 1=low, 3=medium, 5=high)"
@@ -105,7 +124,11 @@ export function taskCommands(program: Command) {
 
         if (options.title) updates.title = options.title;
         if (options.content) updates.content = options.content;
+        if (options.start) updates.startDate = options.start;
         if (options.due) updates.dueDate = options.due;
+        if (options.allDay === true) updates.isAllDay = true;
+        if (options.allDay === false) updates.isAllDay = false;
+        if (options.timezone) updates.timeZone = options.timezone;
 
         if (options.priority) {
           const priority = parseInt(options.priority, 10);

--- a/src/cli/utils/output.ts
+++ b/src/cli/utils/output.ts
@@ -10,12 +10,28 @@ export function formatTask(task: Dida365Task): string {
     `Project: ${task.projectId}`,
   ];
 
+  if (task.desc) {
+    lines.push(`Description: ${task.desc}`);
+  }
+
   if (task.content) {
     lines.push(`Content: ${task.content}`);
   }
 
+  if (task.startDate) {
+    lines.push(`Start: ${task.startDate}`);
+  }
+
   if (task.dueDate) {
     lines.push(`Due: ${task.dueDate}`);
+  }
+
+  if (task.isAllDay) {
+    lines.push(`All Day: Yes`);
+  }
+
+  if (task.timeZone) {
+    lines.push(`Time Zone: ${task.timeZone}`);
   }
 
   if (task.priority) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -11,7 +11,7 @@ export interface Dida365Task {
   title: string;
   content?: string;
   desc?: string;
-  allDay?: boolean;
+  isAllDay?: boolean;
   startDate?: string;
   dueDate?: string;
   timeZone?: string;

--- a/src/mcp/tools/tasks.tool.ts
+++ b/src/mcp/tools/tasks.tool.ts
@@ -68,8 +68,9 @@ export function registerTaskTools(server: McpServer) {
           .describe("Time zone, e.g. 'Asia/Shanghai'"),
       },
     },
-    async (params) => {
-      const result = await batchService.createTask(params);
+    async ({ allDay, ...rest }) => {
+      const taskData = { ...rest, ...(allDay !== undefined && { isAllDay: allDay }) };
+      const result = await batchService.createTask(taskData);
       return {
         content: [
           {
@@ -113,11 +114,12 @@ export function registerTaskTools(server: McpServer) {
         timeZone: z.string().optional().describe("Time zone"),
       },
     },
-    async ({ taskId, projectId, ...rest }) => {
+    async ({ taskId, projectId, allDay, ...rest }) => {
       const result = await batchService.updateTask({
         id: taskId,
         projectId,
         ...rest,
+        ...(allDay !== undefined && { isAllDay: allDay }),
       });
       return {
         content: [


### PR DESCRIPTION
## Summary

This PR brings the CLI to full parity with MCP tools for task date/time operations, and fixes a pre-existing bug where the `isAllDay` field was incorrectly named.

## Changes

### 🔴 Bug Fix: `allDay` → `isAllDay` field naming

The actual Dida365 API uses `isAllDay` (verified via live `/batch/check/0` sync response: `allDay: null, isAllDay: true`). The TypeScript type had `allDay` which caused MCP tools to silently send the wrong field — **all-day task creation via MCP was broken**.

- `types.ts`: `allDay` → `isAllDay`
- `tasks.tool.ts`: MCP keeps user-facing `allDay` schema but maps to `isAllDay` in API payload

### ✨ New CLI options

**`task create` and `task update`:**
- `-s, --start <date>` — Start date (ISO 8601)
- `--all-day` / `--no-all-day` — Toggle all-day flag
- `--timezone <tz>` — Time zone (e.g. `Asia/Shanghai`)
- `--desc <description>` — Plain-text description (distinct from `content`)

### 🔧 Output improvements

`formatTask()` now displays: `startDate`, `desc`, `isAllDay`, `timeZone` (previously invisible in non-JSON output).

### 📝 SKILL.md

- Added new CLI options to documentation
- Fixed `task complete` / `task delete` parameter order (`taskId` before `projectId`)
- Added `--desc` parameter documentation
- Removed duplicate `-j, --json` entry

## Examples

```bash
# Create a task with time block
dida365 task create "Meeting" -p <pid> -s 2026-03-10T09:00:00 -d 2026-03-10T12:00:00 --timezone Asia/Shanghai

# Create an all-day task
dida365 task create "Review" -p <pid> -d 2026-03-10 --all-day

# Reschedule with start + due
dida365 task update <tid> -p <pid> -s 2026-03-15 -d 2026-03-15 --all-day
```

## Motivation

As an AI agent (OpenClaw) managing TickTick tasks via this CLI, being unable to set `startDate` or `isAllDay` via CLI meant falling back to raw `curl` calls to the batch API. This PR eliminates that workaround and fixes a silent bug affecting MCP users.